### PR TITLE
Improvement in handling errors

### DIFF
--- a/buildAllBoards.bat
+++ b/buildAllBoards.bat
@@ -2,7 +2,8 @@
 @echo off
 setlocal
 
-set "percorso_default=C:\Users\vgaggero\Documents\WORKSPACE"
+:: By default, use parent folder of this script as percorso_default
+for %%a in ("%~dp0..") do set "percorso_default=%%~fa"
 
 if "%~1"=="-p" (
   set "percorso_utente=%~2"
@@ -12,6 +13,21 @@ if "%~1"=="-p" (
   echo Nessun percorso utente fornito, utilizzo del percorso predefinito: %percorso_utente%
 )
 
+:: Automatically detect the UV4.exe out of possible default installation paths
+
+echo Percorso utente usato: %percorso_utente%
+
+if exist "C:\Keil_v5\UV4\UV4.exe" (
+    set "UV4_PATH=C:\Keil_v5\UV4\UV4.exe"
+) else (
+    if exist "%LOCALAPPDATA%\Keil_v5\UV4\UV4.exe" (
+        set "UV4_PATH=%LOCALAPPDATA%\Keil_v5\UV4\UV4.exe"
+    ) else (
+        echo "UV4.exe not found."
+    )
+)
+
+echo "Detected Keil's UV4 at %UV4_PATH%"
 
 
 set "pjoj_EMS_path=%percorso_utente%\icub-firmware\emBODY\eBcode\arch-arm\board\ems004\appl\v2\proj\ems4rd.diagnostic2ready.uvprojx"
@@ -28,19 +44,111 @@ set "out_path=%CD%"
 
 
 echo EMS compilation starts...
-C:\Keil_v5\UV4\UV4.exe -o %out_path%\ems.log -b %pjoj_EMS_path% 
+%UV4_PATH% -o %out_path%\ems.log -j0 -b %pjoj_EMS_path%
+set err=%errorlevel%
+if %err%==0 (
+    echo EMS compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: EMS compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\ems.log"
+    ) else (
+        echo ERROR: EMS compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\ems.log"
+        exit /b %err%
+    )
+)
+
 
 echo MC2PLUS compilation starts...
-C:\Keil_v5\UV4\UV4.exe -o %out_path%\mc2plus.log -b %pjoj_MC2PLUS_path%
+%UV4_PATH% -o %out_path%\mc2plus.log -j0 -b %pjoj_MC2PLUS_path%
+set err=%errorlevel%
+if %err%==0 (
+    echo MC2PLUS compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: MC2PLUS compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\mc2plus.log"
+    ) else (
+        echo ERROR: MC2PLUS compilation failed with error code %err%.
+        echo Displaying log file:
+        type "%out_path%\mc2plus.log"
+        exit /b %err%
+    )
+)
 
 echo MC4PLUS compilation starts...
-C:\Keil_v5\UV4\UV4.exe -o %out_path%\mc4plus.log -b %pjoj_MC4PLUS_path%
+%UV4_PATH% -o %out_path%\mc4plus.log -j0 -b %pjoj_MC4PLUS_path%
+set err=%errorlevel%
+if %err%==0 (
+    echo MC4PLUS compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: MC4PLUS compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\mc4plus.log"
+    ) else (
+        echo ERROR: MC4PLUS compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\mc4plus.log"
+        exit /b %err%
+    )
+)
 
 echo AMC compilation starts...
-C:\Keil_v5\UV4\UV4.exe -o %out_path%\amc_lib.log -b %pjoj_AMC_LIB_path%
-C:\Keil_v5\UV4\UV4.exe -o %out_path%\amc_lib_ipal.log -b %pjoj_AMC_LIB_IPAL_path%
-C:\Keil_v5\UV4\UV4.exe -o %out_path%\amc.log -b %pjoj_AMC_path%
+%UV4_PATH% -o %out_path%\amc_lib.log -j0 -b %pjoj_AMC_LIB_path%
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC_LIB compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC_LIB compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc_lib.log"
+    ) else (
+        echo ERROR: AMC_LIB compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc_lib.log"
+        exit /b %err%
+    )
+)
 
+%UV4_PATH% -o %out_path%\amc_lib_ipal.log -j0 -b %pjoj_AMC_LIB_IPAL_path%
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC_LIB_IPAL compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC_LIB_IPAL compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc_lib_ipal.log"
+    ) else (
+        echo ERROR: AMC_LIB compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc_lib_ipal.log"
+        exit /b %err%
+    )
+)
+
+%UV4_PATH% -o %out_path%\amc.log -j0 -b %pjoj_AMC_path%
+set err=%errorlevel%
+if %err%==0 (
+    echo AMC compilation successful.
+) else (
+    if %err%==1 (
+        echo WARNING: AMC compilation produced warnings.
+        echo Compilation log:
+        type "%out_path%\amc.log"
+    ) else (
+        echo ERROR: AMC compilation failed with error code %err%.
+        echo Compilation log:
+        type "%out_path%\amc.log"
+        exit /b %err%
+    )
+)
 
 echo "Compilations Done!!!"
 
@@ -49,7 +157,6 @@ COPY %percorso_utente%\icub-firmware\emBODY\eBcode\arch-arm\board\amc\applicatio
 COPY %percorso_utente%\icub-firmware\emBODY\eBcode\arch-arm\board\ems004\appl\v2\bin\*.hex %percorso_utente%\icub-firmware-build\ETH\EMS\bin\application
 COPY %percorso_utente%\icub-firmware\emBODY\eBcode\arch-arm\board\mc2plus\appl\v2\bin\*.hex %percorso_utente%\icub-firmware-build\ETH\MC2PLUS\bin\application
 COPY %percorso_utente%\icub-firmware\emBODY\eBcode\arch-arm\board\mc4plus\appl\v2\bin\*.hex %percorso_utente%\icub-firmware-build\ETH\MC4PLUS\bin\application
-
 
 echo "Copy Done!!!"
 


### PR DESCRIPTION
Several suggestions for improvements:
* Support default UV4 location when using latest Keil MDK (as a fallback of `C:\Keil_v5\UV4\UV4.exe`)
* Early exit and print log if a compilation for a bord fail
* If not folder is explicitly passed, assume that the icub-firmware folder is at the same level of the AutoFirmwareCompilation repo (i.e. use parent folder of the folder in which the script is contained as `percorso_utente`)
* Pass `-j0` to the UV4 invocation, to avoid that the GUI is launched

@valegagge feel free to reject part of the changes, I wanted just to track my improvements suggestions somewhere. Beside that the script is great, could it make sense to have it directly in icub-firmware? 